### PR TITLE
Fixed: QR code size too big (#116)

### DIFF
--- a/services/qrcode.ts
+++ b/services/qrcode.ts
@@ -2,7 +2,7 @@ import jsPDF from "jspdf";
 import QRCode from 'qrcode';
 
 export const generateQRCodesPDF = async (voteUrls) => {
-    const doc = new jsPDF('p', 'mm', 'a4');
+    const doc = new jsPDF('p', 'mm', 'a4', true);
     const pageWidth = doc.internal.pageSize.getWidth();
     const pageHeight = doc.internal.pageSize.getHeight();
     const qrCodeSize = 47; // Taille de chaque QR code


### PR DESCRIPTION
With this simple change, the size of the PDF that contains the QR codes is reduced from around 271Mo to around 3Mo for 1000 QR codes.