### PR TITLE
Fixed: ensure text and placeholder visibility in admin modals (#172)

### DIFF
--- a/components/admin/CandidateModalSet.tsx
+++ b/components/admin/CandidateModalSet.tsx
@@ -157,7 +157,7 @@ const CandidateModal = ({isOpen, position, toggle}) => {
             <div className="my-3">
               <Label className="fw-bold text-dark">{t('common.name')} </Label>
               <input
-                className="form-control text-dark"
+                className="form-control"
                 type="text"
                 placeholder={t('admin.candidate-name-placeholder')}
                 tabIndex={position + 1}

--- a/components/admin/GradeModalAdd.tsx
+++ b/components/admin/GradeModalAdd.tsx
@@ -57,11 +57,11 @@ const GradeModal = ({isOpen, toggle}) => {
       </div>
 
       <ModalBody className="p-4">
-        <p>{t('admin.add-grade-desc')}</p>
+        <p className="text-dark">{t('admin.add-grade-desc')}</p>
         <Col>
           <Form className="container container-fluid" onSubmit={save}>
             <div className="mb-3">
-              <Label className="fw-bold">{t('common.name')} </Label>
+              <Label className="fw-bold text-dark">{t('common.name')} </Label>
               <Input
                 type="text"
                 placeholder={t('admin.grade-name-placeholder')}

--- a/components/admin/GradeModalSet.tsx
+++ b/components/admin/GradeModalSet.tsx
@@ -57,11 +57,11 @@ const GradeModal = ({isOpen, toggle, value}) => {
       </div>
 
       <ModalBody className="p-4">
-        <p>{t('admin.add-grade-desc')}</p>
+        <p className="text-dark">{t('admin.add-grade-desc')}</p>
         <Col>
           <Form className="container container-fluid" onSubmit={handleSubmit}>
             <div className="mb-3">
-              <Label className="fw-bold">{t('common.name')} </Label>
+              <Label className="fw-bold text-dark">{t('common.name')} </Label>
               <Input
                 type="text"
                 placeholder={t('admin.grade-name-placeholder')}

--- a/components/admin/TitleModal.tsx
+++ b/components/admin/TitleModal.tsx
@@ -92,7 +92,7 @@ const TitleModal = ({isOpen, toggle}) => {
       <ModalBody className="p-4">
         <Form className="container container-fluid" onKeyDown={handleKeyDown}>
           <div className="mb-3">
-            <Label className="fw-bold">{t('common.name')} </Label>
+            <Label className="fw-bold text-dark">{t('common.name')} </Label>
             <Input
               type="text"
               placeholder={t('home.writeQuestion')}

--- a/styles/scss/_admin.scss
+++ b/styles/scss/_admin.scss
@@ -52,7 +52,7 @@
 
 .modal
   > *
-  :is(input[type='text'], input[type='text']:focus, input[type='text']::placeholder), textarea, textarea:focus, textarea::placeholder {
+  :is(input[type='text'], input[type='text']:focus), textarea, textarea:focus {
   background: white;
   border-radius: 0px;
   color: black !important;
@@ -64,8 +64,10 @@
 .modal > * input[type='text']:focus {
   opacity: 0.8;
 }
-.modal > * input[type='text']:placeholder {
-  opacity: 0.4;
+.modal > * input[type='text']::placeholder,
+.modal > * textarea::placeholder {
+  color: black !important;
+  opacity: 1 !important;
 }
 
 .params {


### PR DESCRIPTION
## Summary
- Fixed placeholder text and label text appearing invisible (white on white)
  in admin modals: Title, Grade Add, and Grade Set
- Root cause: `:is()` cannot contain `::placeholder` pseudo-elements — browsers
  silently dropped the rule, so `color: black !important` never applied to placeholders
## Changes
**CSS fix** (`styles/scss/_admin.scss`):
- Removed `::placeholder` from the invalid `:is()` selector
- Added standalone `::placeholder` rules with `color: black !important` and
  `opacity: 1 !important` for both `input[type='text']` and `textarea`
- Replaced the original broken `:placeholder` (single colon) rule
**Component fixes** (admin modals):
- Added `text-dark` to `<Label>` elements in `TitleModal.tsx`,
  `GradeModalAdd.tsx`, and `GradeModalSet.tsx`
- Added `text-dark` to description `<p>` elements in `GradeModalAdd.tsx` and
  `GradeModalSet.tsx`
- Removed now-unnecessary `text-dark` from the input in `CandidateModalSet.tsx`
  (CSS handles it consistently now)